### PR TITLE
feat: upgrade WebDriverIO to v9, TypeScript to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,20 +7,21 @@
   "version": "0.0.1",
   "dependencies": {
     "mocha": "^10.2.0",
-    "webdriverio": "^8.21.0"
+    "webdriverio": "^9.0.0"
   },
   "devDependencies": {
-    "@wdio/cli": "^8.21.0",
-    "@wdio/globals": "^8.21.0",
-    "@wdio/junit-reporter": "^8.21.0",
-    "@wdio/local-runner": "^8.21.0",
-    "@wdio/mocha-framework": "^8.21.0",
-    "@wdio/spec-reporter": "^8.21.0",
-    "@wdio/types": "^8.21.0",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.2.2"
+    "@wdio/cli": "^9.0.0",
+    "@wdio/globals": "^9.0.0",
+    "@wdio/junit-reporter": "^9.0.0",
+    "@wdio/local-runner": "^9.0.0",
+    "@wdio/mocha-framework": "^9.0.0",
+    "@wdio/spec-reporter": "^9.0.0",
+    "@wdio/types": "^9.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
   },
   "scripts": {
+    "build": "tsc --noEmit",
     "prewdio-local": "npm install",
     "wdio-local": "wdio run ./wdio.local.conf.ts",
     "prewdio-device-farm": "npm install",

--- a/wdio.devicefarm.conf.ts
+++ b/wdio.devicefarm.conf.ts
@@ -1,10 +1,8 @@
-import type { Options } from '@wdio/types'
-
 /**
  * Webdriver.IO configuration file for local tests execution.
  * See: https://webdriver.io/docs/configurationfile/
  */
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.Config = {
     //
     // ====================
     // Runner Configuration
@@ -20,13 +18,8 @@ export const config: Options.Testrunner = {
     port: 4723,
     path: '/wd/hub',
 
-    autoCompileOpts: {
-        autoCompile: true,
-        tsNodeOpts: {
-            project: './tsconfig.json',
-            transpileOnly: true
-        }
-    },
+    // Note: WDIO v9 uses tsx instead of ts-node for TypeScript compilation.
+    // autoCompileOpts is no longer needed.
     //
     // ==================
     // Specify Test Files

--- a/wdio.local.conf.ts
+++ b/wdio.local.conf.ts
@@ -1,4 +1,3 @@
-import type { Options } from '@wdio/types'
 import * as path from 'path';
 
 const appBinaryPath = path.resolve('./apk/application.apk');
@@ -7,7 +6,7 @@ const appBinaryPath = path.resolve('./apk/application.apk');
  * Webdriver.IO configuration file for local tests execution.
  * See: https://webdriver.io/docs/configurationfile/
  */
-export const config: Options.Testrunner = {
+export const config: WebdriverIO.Config = {
     //
     // ====================
     // Runner Configuration
@@ -23,13 +22,8 @@ export const config: Options.Testrunner = {
     port: 4723,
     //path: '/wd/hub',  // Use this configuration for Appium v 1.x
 
-    autoCompileOpts: {
-        autoCompile: true,
-        tsNodeOpts: {
-            project: './tsconfig.json',
-            transpileOnly: true
-        }
-    },
+    // Note: WDIO v9 uses tsx instead of ts-node for TypeScript compilation.
+    // autoCompileOpts is no longer needed.
     //
     // ==================
     // Specify Test Files


### PR DESCRIPTION
## Summary

Upgrades all WebDriverIO packages from v8 to v9 and TypeScript to latest 5.x.

## Changes

- Updated all `@wdio/*` packages and `webdriverio` from `^8.x` to `^9.x`
- Updated `typescript` to `^5.7.0`
- Replaced `ts-node` with `tsx` (WDIO v9 uses tsx natively for TS compilation)
- Removed deprecated `autoCompileOpts` from both wdio config files (no longer needed in v9)
- Changed config type from `Options.Testrunner` to `WebdriverIO.Config` (v9 type restructure that includes capabilities)
- Added `build` script to package.json for `tsc --noEmit`

## Breaking Changes Addressed

- **ts-node → tsx**: WDIO v9 migrated from ts-node to tsx for better ESM support
- **autoCompileOpts removed**: No longer needed; WDIO v9 handles TS compilation automatically
- **Type restructure**: `Options.Testrunner` no longer includes `capabilities`; `WebdriverIO.Config` is the correct type

## Verification

- `npm install` succeeds
- `tsc --noEmit` passes with no errors