### PR TITLE
chore: bump WDIO 9.31.x, tsx 4.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,17 +7,17 @@
   "version": "0.0.1",
   "dependencies": {
     "mocha": "^10.2.0",
-    "webdriverio": "^9.0.0"
+    "webdriverio": "^9.31.2"
   },
   "devDependencies": {
-    "@wdio/cli": "^9.0.0",
-    "@wdio/globals": "^9.0.0",
-    "@wdio/junit-reporter": "^9.0.0",
-    "@wdio/local-runner": "^9.0.0",
-    "@wdio/mocha-framework": "^9.0.0",
-    "@wdio/spec-reporter": "^9.0.0",
-    "@wdio/types": "^9.0.0",
-    "tsx": "^4.19.0",
+    "@wdio/cli": "^9.31.2",
+    "@wdio/globals": "^9.31.1",
+    "@wdio/junit-reporter": "^9.31.2",
+    "@wdio/local-runner": "^9.31.2",
+    "@wdio/mocha-framework": "^9.31.2",
+    "@wdio/spec-reporter": "^9.31.2",
+    "@wdio/types": "^9.31.2",
+    "tsx": "^4.23.12",
     "typescript": "^5.7.0"
   },
   "scripts": {


### PR DESCRIPTION
Safe minor bumps within existing major ranges:
- WebDriverIO ecosystem: 9.0.0 -> 9.31.x
- tsx: 4.19.0 -> 4.23.12

No breaking changes (all within ^range).